### PR TITLE
Make "on change" history logging working for getHistory 

### DIFF
--- a/main.js
+++ b/main.js
@@ -378,7 +378,7 @@ function getHistory(msg) {
     query += " time < '" + new Date(options.end).toISOString() + "'";
 
     if (options.step && options.aggregate !== 'onchange') {
-        query += ' GROUP BY time(' + options.step + 'ms)';
+        query += ' GROUP BY time(' + options.step + 'ms) fill(previous)';
         if (options.limit) query += ' LIMIT ' + options.limit;
     } else {
         query += ' LIMIT ' + options.count;


### PR DESCRIPTION
InfluxDB returns a 0 when there is no value in the timeframe. With „log
changes only“ this can happen quite often. This lead in returning wrong
values.
Added „fill(previous)“ to query to make sure that the last value is
used when no value is found.