### PR TITLE
Add Buffering Support

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -60,6 +60,10 @@
         "Encrypt:":             {"en": "Encrypt:",              "de": "Verschlüsseln:",                 "ru": "Шифрование:"},
         "Test connection":      {"en": "Test connection",       "de": "Verbindung testen",              "ru": "Проверить соединение"},
         "Round real to":        {"en": "Round real to",         "de": "Aufrunden auf",                  "ru": "Округлять до"},
+        "Buffer Datapoints":    {"en": "Buffer Datapoints",     "de": "Schreibaktionen sammeln",        "ru": "Buffer Datapoints"},
+        "use 0 to not buffer at all":    {"en": "Use 0 to not buffer at all",     "de": "Wert 0 schreibt Werte direkt",        "ru": "Buse 0 to not buffer at all"},
+        "Buffer Flush Interval":    {"en": "Buffer Flush Interval",     "de": "Schreibintervall",       "ru": "Buffer Flush Interval"},
+        "Seconds":              {"en": "Seconds",               "de": "Sekunden",                       "ru": "Seconds"},
         "Are you sure? All data will be dropped.": {
             "en": "Are you sure? All data will be dropped.",
             "de": "Sind Sie sicher? ALLE Daten werden geöscht.",
@@ -324,6 +328,16 @@
             <td class="translate">Round real to</td>
             <td><input id="round" type="text" class="value"/></td>
             <td class="translate"></td>
+        </tr>
+        <tr>
+            <td class="translate">Buffer Datapoints</td>
+            <td><input id="seriesBufferMax" type="text" class="value"/></td>
+            <td class="translate">use 0 to not buffer at all</td>
+        </tr>
+        <tr>
+            <td class="translate">Buffer Flush Interval</td>
+            <td><input id="seriesBufferFlushInterval" type="text" class="value"/></td>
+            <td class="translate">Seconds</td>
         </tr>
         <tr><td colspan="3"><h4 class="translate">Default settings</h4></td></tr>
         <tr>

--- a/converter/history2influx.js
+++ b/converter/history2influx.js
@@ -1,0 +1,12 @@
+/* jshint -W097 */// jshint strict:false
+/*jslint node: true */
+"use strict";
+
+//noinspection JSUnresolvedFunction
+var utils  = require(__dirname + '/lib/utils'); // Get common adapter utils
+var influxInstance = "influxdb.0";
+
+adapter.sendTo(influxInstance, "storeState", {
+    state: {'result': rows, 'ts': new Date().getTime()},
+    id:  ""
+}, msg.callback);

--- a/io-package.json
+++ b/io-package.json
@@ -73,15 +73,17 @@
         }
     },
     "native": {
-        "debounce":  10000,
-        "retention": 31536000,
-        "dbname":    "iobroker",
-        "host":      "localhost",
-        "protocol":  "http",
-        "port":      8086,
-        "user":      "",
-        "password":  "",
-        "round":     4
+        "debounce":                  10000,
+        "retention":                 31536000,
+        "dbname":                    "iobroker",
+        "host":                      "localhost",
+        "protocol":                  "http",
+        "port":                      8086,
+        "user":                      "",
+        "password":                  "",
+        "round":                     4,
+        "seriesBufferMax":           0,
+        "seriesBufferFlushInterval": 600
     },
     "objects": [
         {

--- a/main.js
+++ b/main.js
@@ -378,7 +378,7 @@ function getHistory(msg) {
     query += " time < '" + new Date(options.end).toISOString() + "'";
 
     if (options.step && options.aggregate !== 'onchange') {
-        query += ' GROUP BY time(' + options.step + 'ms)';
+        query += ' GROUP BY time(' + options.step + 'ms) fill(previous)';
         if (options.limit) query += ' LIMIT ' + options.limit;
     } else {
         query += ' LIMIT ' + options.count;

--- a/main.js
+++ b/main.js
@@ -202,6 +202,8 @@ function processMessage(msg) {
         generateDemo(msg);
     } else if (msg.command == 'query') {
         query(msg);
+    } else if (msg.command == 'storeState') {
+        storeState(msg);
     }
 }
 
@@ -599,6 +601,22 @@ function query(msg) {
             error:  'No connection'
         }, msg.callback);
     }
+}
+
+function storeState(msg) {
+    if (!msg.message || !msg.message.id || !msg.message.state) {
+        adapter.log.error('storeState called with invalid data');
+        adapter.sendTo(msg.from, msg.command, {
+            error:  'Invalid call'
+        }, msg.callback);
+        return;
+    }
+    addValueToBuffer(msg.message.id, msg.message.state);
+    //to remove when buffering comes really in
+    pushValueIntoDB(msg.message.id, msg.message.state);
+
+    adapter.sendTo(msg.from, msg.command, 'stored', msg.callback);
+
 }
 
 process.on('uncaughtException', function (err) {

--- a/main.js
+++ b/main.js
@@ -5,14 +5,16 @@
 //noinspection JSUnresolvedFunction
 var utils  = require(__dirname + '/lib/utils'); // Get common adapter utils
 var influx = require('influx');
+var fs = require('fs');
 
-var subscribeAll = false;
-var influxDPs    = {};
+var subscribeAll        = false;
+var influxDPs           = {};
 var client;
 var seriesBufferChecker = null;
 var seriesBufferCounter = 0;
 var seriesBuffer        = {};
-var conflictingPoints   = [];
+var conflictingPoints   = {};
+var errorPoints         = {};
 
 var adapter = utils.adapter('influxdb');
 
@@ -59,6 +61,13 @@ adapter.on('message', function (msg) {
 });
 
 process.on('SIGINT', function () {
+    if (adapter && adapter.setState) {
+        finish();
+    }
+});
+
+process.on('uncaughtException', function (err) {
+    adapter.log.warn('Exception: ' + err);
     if (adapter && adapter.setState) {
         finish();
     }
@@ -227,6 +236,26 @@ function main() {
 
     adapter.config.seriesBufferFlushInterval = parseInt(adapter.config.seriesBufferFlushInterval, 10) || 600;
 
+    try {
+        if (fs.statSync(__dirname + '/../../iobroker-data/iobroker.influxdata.json').isFile()) {
+            var fileContent = fs.readFileSync(__dirname + '/../../iobroker-data/iobroker.influxdata.json');
+            var tempData = JSON.parse(fileContent, function(key, value) {
+                if (key === 'time') {
+                  return new Date(value);
+                }
+                return value;
+            });
+            if (tempData.seriesBufferCounter) seriesBufferCounter = tempData.seriesBufferCounter;
+            if (tempData.seriesBuffer) seriesBuffer = tempData.seriesBuffer;
+            if (tempData.conflictingPoints) conflictingPoints = tempData.conflictingPoints;
+            adapter.log.info('Buffer initialized with data for ' + seriesBufferCounter + ' points and ' + Object.keys(conflictingPoints).length + ' conflicts from last exit');
+            fs.unlinkSync(__dirname + '/../../iobroker-data/iobroker.influxdata.json');
+        }
+    }
+    catch (err) {
+        adapter.log.info('No stored data from last exit found');
+    }
+
     fixSelector(function () {
         // read all custom settings
         adapter.objects.getObjectView('custom', 'state', {}, function (err, doc) {
@@ -277,12 +306,8 @@ function main() {
 
     adapter.subscribeForeignObjects('*');
 
-    if (adapter.config.seriesBufferMax>0) {
-        // store all buffered data every 10 minutes to not lost the data
-        seriesBufferChecker = setInterval(function () {
-            storeBufferedSeries();
-        }, adapter.config.seriesBufferFlushInterval*1000);
-    }
+    // store all buffered data every x seconds to not lost the data
+    seriesBufferChecker = setInterval(storeBufferedSeries, adapter.config.seriesBufferFlushInterval*1000);
 
     connect();
 }
@@ -353,7 +378,7 @@ function pushValueIntoDB(id, state) {
         if (f == state.val) state.val = f;
     }
 
-    adapter.log.debug('write value ' + state.val + ' for ' + id);
+    //adapter.log.debug('write value ' + state.val + ' for ' + id);
     var influxFields = {
         value: state.val,
         time:  new Date(state.ts),
@@ -362,11 +387,14 @@ function pushValueIntoDB(id, state) {
         ack:   state.ack
     };
 
-    if (conflictingPoints[id] || (adapter.config.seriesBufferMax===0)) {
-        if (adapter.config.seriesBufferMax!==0)
-            adapter.log.info('Direct writePoint("' + id + ' - ' + influxFields.value + ' / ' + influxFields.time + ')');
+    if ((conflictingPoints[id] || (adapter.config.seriesBufferMax === 0)) && (client.request) && (client.request.getHostsAvailable().length > 0)) {
+        if (adapter.config.seriesBufferMax !== 0)
+            adapter.log.debug('Direct writePoint("' + id + ' - ' + influxFields.value + ' / ' + influxFields.time + ')');
         client.writePoint(id, influxFields, null, function (err, result) {
-            if (err) adapter.log.warn('writePoint("' + JSON.stringify(influxFields) + '): ' + err);
+            if (err) {
+                adapter.log.warn('writePoint("' + id + ' - ' + JSON.stringify(influxFields) + '): ' + err);
+                if (client.request.getHostsAvailable().length == 0) addPointToSeriesBuffer(id, influxFields);
+            }
         });
     }
     else {
@@ -378,62 +406,84 @@ function addPointToSeriesBuffer(id, stateObj) {
     if (!seriesBuffer[id]) seriesBuffer[id] = [];
     seriesBuffer[id].push([stateObj]);
     seriesBufferCounter++;
-    if (seriesBufferCounter > adapter.config.seriesBufferMax) {
-      //flush out
-      storeBufferedSeries();
+    if ((seriesBufferCounter > adapter.config.seriesBufferMax) && (client.request) && (client.request.getHostsAvailable().length > 0)) {
+        //flush out
+        storeBufferedSeries();
     }
 }
 
-function storeBufferedSeries() { //TODO!!!
+function storeBufferedSeries() {
+    if (Object.keys(seriesBuffer).length === 0) return;
+
+    if (client.request.getHostsAvailable().length === 0) {
+        adapter.log.info('No hosts available currently, try later');
+        return;
+    }
     adapter.log.info('Store ' + seriesBufferCounter + ' buffered influxDB history points');
 
     var seriesToWrite = seriesBuffer;
     seriesBuffer = {};
     seriesBufferCounter = 0;
 
+    if (seriesBufferChecker) clearInterval(seriesBufferChecker);
+    seriesBufferChecker = setInterval(storeBufferedSeries, adapter.config.seriesBufferFlushInterval*1000);
+
     client.writeSeries(seriesToWrite, function (err, result) {
-        // {"error":"field type conflict"} HTTP 400
         if (err) {
             adapter.log.warn('Error on writeSeries: ' + err);
-            adapter.log.warn('Try to write ' + Object.keys(seriesToWrite).length + ' Points separate to find the conflicting id');
-            // fallback and send data per id to find out problematic id!
-            for (var id in seriesToWrite) {
-                (function(seriesId, points) {
-                    adapter.log.debug('writePoints for ' + seriesId);
-                    client.writePoints(seriesId, points, function(err) {
-                        if (err) {
-                            adapter.log.warn('Error on writePoints for ' + seriesId + ': ' + err);
-                            adapter.log.warn('Try to write ' + points.length + ' Points separate to find the conflicting one');
-                            // we found the conflicting id
-                            for (var i = 0; i < points.length; i++) {
-                                (function(pointId, point) {
-                                    client.writePoint(pointId, point, null, function (err, result) {
-                                        if (err) {
-                                            adapter.log.warn('Error on writePoint("' + JSON.stringify(point) + '): ' + err);
-                                            if ((typeof err === 'string') && (err.indexof('field type conflict') !== -1)) {
-                                                // remember this as a pot. conflicing point and write synchronous
-                                                conflictingPoints[pointId]=1;
-                                                adapter.log.warn('Add ' + pointId + ' to conflicting Points (' + conflictingPoints.keys().length + ' now)');
+            if (client.request.getHostsAvailable().length == 0) {
+                adapter.log.info('Host not available, move all points back in the Buffer');
+                // error caused InfluxDB client to remove the host from available for now
+                for (var id in seriesToWrite) {
+                    for (var i = 0; i < seriesToWrite[id].length; i++) {
+                        if (!seriesBuffer[id]) seriesBuffer[id] = [];
+                        seriesBuffer[id].push(seriesToWrite[id][i]);
+                        seriesBufferCounter++;
+                    }
+                }
+            }
+            else if (err.message && (typeof err.message === 'string') && (err.message.indexOf('partial write') !== -1)) {
+                adapter.log.warn('All possisble datapoints were written, others can not really be corrected');
+            }
+            else {
+                adapter.log.debug('Try to write ' + Object.keys(seriesToWrite).length + ' Points separate to find the conflicting id');
+                // fallback and send data per id to find out problematic id!
+                for (var id in seriesToWrite) {
+                    (function(seriesId, points) {
+                        adapter.log.debug('writePoints for ' + seriesId);
+                        client.writePoints(seriesId, points, function(err) {
+                            if (err) {
+                                adapter.log.warn('Error on writePoints for ' + seriesId + ': ' + err);
+                                adapter.log.warn('Try to write ' + points.length + ' Points separate to find the conflicting one');
+                                // we found the conflicting id
+                                for (var i = 0; i < points.length; i++) {
+                                    (function(pointId, point) {
+                                        client.writePoint(pointId, point, null, function (err, result) {
+                                            if (err) {
+                                                adapter.log.warn('Error on writePoint("' + JSON.stringify(point) + '): ' + err + ' / ' + JSON.stringify(err.message));
+                                                if (err.message && (typeof err.message === 'string') && (err.message.indexOf('field type conflict') !== -1)) {
+                                                    // remember this as a pot. conflicing point and write synchronous
+                                                    conflictingPoints[pointId]=1;
+                                                    adapter.log.info('Add ' + pointId + ' to conflicting Points (' + Object.keys(conflictingPoints).length + ' now)');
+                                                }
+                                                else {
+                                                    if (! errorPoints[pointId]) errorPoints[pointId]=1;
+                                                        else errorPoints[pointId]++;
+                                                    if (errorPoints[pointId]<10) {
+                                                        // re-add that point to buffer to try write again
+                                                        adapter.log.info('Add point that had error for ' + pointId + ' to buffer again, error-count=' + errorPoints[pointId]);
+                                                        addPointToSeriesBuffer(pointId, point);
+                                                    }
+                                                    else errorPoints[pointId]=0;
+                                                }
                                             }
-                                            else if (err.error && (err.error.indexof('field type conflict') !== -1)) {
-                                                // remember this as a pot. conflicing point and write synchronous
-                                                conflictingPoints[pointId]=1;
-                                                adapter.log.warn('Add2 ' + pointId + ' to conflicting Points (' + conflictingPoints.keys().length + ' now)');
-                                            }
-                                            else {
-                                                adapter.log.warn('1: ' + (typeof err) + ' - ' + err.indexof('field type conflict'));
-                                                if (err.error) adapter.log.warn('2: ' + (typeof err.error) + ' - ' + err.error.indexof('field type conflict'));
-                                                // re-add that point to buffer to try write again
-                                                addPointToSeriesBuffer(pointId, point);
-                                                adapter.log.warn('Add point that had error for ' + pointId + ' to buffer again');
-                                            }
-                                        }
-                                    });
-                                })(seriesId,points[i][0]);
+                                        });
+                                    })(seriesId,points[i][0]);
+                                }
                             }
-                        }
-                    });
-                })(id, seriesToWrite[id]);
+                        });
+                    })(id, seriesToWrite[id]);
+                }
             }
         }
     });
@@ -442,8 +492,14 @@ function storeBufferedSeries() { //TODO!!!
 function finish(callback) {
     if (seriesBufferChecker) clearInterval(seriesBufferChecker);
 
-    storeBufferedSeries();
+    var fileData = {};
+    fileData.seriesBufferCounter = seriesBufferCounter;
+    fileData.seriesBuffer = seriesBuffer;
+    fileData.conflictingPoints = conflictingPoints;
+    fs.writeFileSync(__dirname + '/../../iobroker-data/iobroker.influxdata.json',JSON.stringify(fileData));
+    adapter.log.warn('Store data for ' + fileData.seriesBufferCounter + ' points and ' + Object.keys(fileData.conflictingPoints).length + ' conflicts');
     if (callback) callback();
+      else process.exit();
 }
 
 function getHistory(msg) {
@@ -697,7 +753,7 @@ function query(msg) {
 }
 
 function storeState(msg) {
-    if (!msg.message || !msg.message.id || !msg.message.state || (Array.isArray(msg.message))) {
+    if (!msg.message || !msg.message.id || !msg.message.state) {
         adapter.log.error('storeState called with invalid data');
         adapter.sendTo(msg.from, msg.command, {
             error:  'Invalid call'
@@ -706,23 +762,18 @@ function storeState(msg) {
     }
 
     if (Array.isArray(msg.message)) {
-      for (i = 0;i < msg.message.length;i++) {
-          pushValueIntoDB(msg.message[i].id, msg.message[i].state[i]);
-      }
+        for (i = 0;i < msg.message.length; i++) {
+            pushValueIntoDB(msg.message[i].id, msg.message[i].state);
+        }
     }
     else if (Array.isArray(msg.message.state)) {
-      for (i = 0;i < msg.message.state.length;i++) {
-          pushValueIntoDB(msg.message.id, msg.message.state[i]);
-      }
+        for (i = 0;i < msg.message.state.length;i++) {
+            pushValueIntoDB(msg.message.id, msg.message.state[i]);
+        }
     }
     else {
         pushValueIntoDB(msg.message.id, msg.message.state);
     }
 
     adapter.sendTo(msg.from, msg.command, 'stored', msg.callback);
-
 }
-
-process.on('uncaughtException', function (err) {
-    adapter.log.warn('Exception: ' + err);
-});


### PR DESCRIPTION
This pull requests brings:
- introduce buffering to not send each single datapoint change directly into the DB to increase performance on ioBroker- and InfluxDB-hosts. Field type conflicts are handled too and potential conflicting points will be send directly
- additionally the adapter tries to detect when the InfluxDB is unavailable and also uses the buffer to do not loose datapoints. They will be written as soon as InfluxDB is available again
- added documentation for new feature, but also about field types and such