### PR TITLE
Expose flush buffer

### DIFF
--- a/main.js
+++ b/main.js
@@ -359,6 +359,11 @@ function processMessage(msg) {
                     }, 1500);
                 }
             }
+        } else {
+            /* no connection? */
+            if (msg.callback) {
+                adapter.sendTo(msg.from, msg.command, false, msg.callback);
+            }
         }
     }
 }


### PR DESCRIPTION
This allows other adapters to instruct the influx adapter to write the cached values to disk. 
Otherwise queries to db will not contain cached values.