### PR TITLE
Influx 2: fixed bug for retention policy update warning

### DIFF
--- a/admin/jsonConfig.json
+++ b/admin/jsonConfig.json
@@ -227,8 +227,8 @@
         "retentionConfirm": {
           "type": "checkbox",
           "label": "Apply lower retention",
-          "hidden": "data.retention >= originalData.retention || data.retention == 0",
-          "disabled": "data.retention >= originalData.retention || data.retention == 0",
+          "hidden": "(data.retention >= originalData.retention && originalData.retention != 0) || data.retention == 0",
+          "disabled": "(data.retention >= originalData.retention && originalData.retention != 0) || data.retention == 0",
           "confirm": {
             "text": "Lowering the retention period should be considered with caution: Past data exceeding the retention period will be lost.",
             "condition": "data.retentionConfirm && data.retentionConfirm != originalData.retentionConfirm",


### PR DESCRIPTION
Fixes issues with missing warning when changing retention from unlimited to any value, mentioned here: https://github.com/ioBroker/ioBroker.influxdb/issues/126.