### PR TITLE
Small fix for the getHistory/getHistoryIflx2 to decrease possible time difference for first and last items from the desired interval borders

### DIFF
--- a/main.js
+++ b/main.js
@@ -1630,6 +1630,7 @@ function getHistoryIflx2(adapter, msg) {
                             delete rows[qr][rr].value;
                         }
                         rows[qr][rr].ts  = new Date(rows[qr][rr].time).getTime();
+                        delete rows[qr][rr].time;
                         if (rows[qr][rr].val !== null) {
                             const f = parseFloat(rows[qr][rr].val);
                             if (f == rows[qr][rr].val) {

--- a/main.js
+++ b/main.js
@@ -1416,13 +1416,13 @@ function getHistory(adapter, msg) {
         if ((result.length > 0) && ((options.aggregate === 'minmax' || options.aggregate === 'onchange' || options.aggregate === 'none'))) {
             if (options.start) {
                 const startTime = new Date(options.start).getTime();
-                if (startTime - result[0].time > 1000) {
-                    result[0].time = startTime - 1000
+                if (startTime - result[0].ts > 1000) {
+                    result[0].ts = startTime - 1000
                 }
             }
             const endTime = new Date(options.end).getTime();
-            if ( (result[result.length - 1].time - endTime ) > 1000) {
-                result[result.length - 1].time  = endTime + 1000;
+            if ( (result[result.length - 1].ts - endTime ) > 1000) {
+                result[result.length - 1].ts  = endTime + 1000;
             }   
         }
 
@@ -1626,7 +1626,6 @@ function getHistoryIflx2(adapter, msg) {
                             delete rows[qr][rr].value;
                         }
                         rows[qr][rr].ts  = new Date(rows[qr][rr].time).getTime();
-                        delete rows[qr][rr].time;
                         if (rows[qr][rr].val !== null) {
                             const f = parseFloat(rows[qr][rr].val);
                             if (f == rows[qr][rr].val) {
@@ -1645,13 +1644,13 @@ function getHistoryIflx2(adapter, msg) {
             if ((result.length > 0) && ((options.aggregate === 'minmax' || options.aggregate === 'onchange' || options.aggregate === 'none'))) {
                 if (options.start) {
                     const startTime = new Date(options.start).getTime();
-                    if (startTime - result[0].time > 1000) {
-                        result[0].time = startTime - 1000
+                    if (startTime - result[0].ts > 1000) {
+                        result[0].ts = startTime - 1000
                     }
                 }
                 const endTime = new Date(options.end).getTime();
-                if ( (result[result.length - 1].time - endTime ) > 1000) {
-                    result[result.length - 1].time  = endTime + 1000;
+                if ( (result[result.length - 1].ts - endTime ) > 1000) {
+                    result[result.length - 1].ts  = endTime + 1000;
                 }   
             }   
 

--- a/main.js
+++ b/main.js
@@ -1390,7 +1390,6 @@ function getHistory(adapter, msg) {
         adapter.log.debug('ROWS:' + JSON.stringify(rows));
         let result = [];
         if (rows && rows.length) {
-            const rowsLast = rows.length - 1;
             for (let qr = 0; qr < rows.length; qr++) {
                 for (let rr = 0; rr < rows[qr].length; rr++) {
                     if ((rows[qr][rr].val === undefined) && (rows[qr][rr].value !== undefined)) {
@@ -1620,14 +1619,13 @@ function getHistoryIflx2(adapter, msg) {
             adapter.log.debug('Parsing retrieved rows:' + JSON.stringify(rows));
             let result = [];
             if (rows && rows.length) {
-                const rowsLast = rows.length - 1;
                 for (let qr = 0; qr < rows.length; qr++) {
                     for (let rr = 0; rr < rows[qr].length; rr++) {
                         if ((rows[qr][rr].val === undefined) && (rows[qr][rr].value !== undefined)) {
                             rows[qr][rr].val = rows[qr][rr].value;
                             delete rows[qr][rr].value;
                         }
-                        rows[qr][rr].ts  = new Date(rows[qr][rr].time).getTime();                     
+                        rows[qr][rr].ts  = new Date(rows[qr][rr].time).getTime();
                         delete rows[qr][rr].time;
                         if (rows[qr][rr].val !== null) {
                             const f = parseFloat(rows[qr][rr].val);

--- a/main.js
+++ b/main.js
@@ -1256,6 +1256,10 @@ function finish(adapter, callback) {
     }
 }
 
+function interpolateData(itemOne, itemTwo, ts) {
+    return {'val' : itemOne.val + (itemTwo.val - itemOne.val)/(itemTwo.ts - itemOne.ts)*(ts - itemOne.ts), 'ts': ts};
+}
+
 function getHistory(adapter, msg) {
     const options = {
         id:         msg.message.id === '*' ? null : msg.message.id,
@@ -1413,16 +1417,16 @@ function getHistory(adapter, msg) {
             }
         }
 
-        if ((result.length > 0) && ((options.aggregate === 'minmax' || options.aggregate === 'onchange' || options.aggregate === 'none'))) {
-            if (options.start) {
+        if ((result.length > 2) && ((options.aggregate === 'minmax' || options.aggregate === 'onchange' || options.aggregate === 'none'))) {
+            if (options.start ) {
                 const startTime = new Date(options.start).getTime();
-                if (startTime - result[0].ts > 1000) {
-                    result[0].ts = startTime - 1000
+                if (startTime > result[0].ts) {
+                    result[0] = interpolateData(result[0], result[1], startTime);
                 }
             }
             const endTime = new Date(options.end).getTime();
-            if ( (result[result.length - 1].ts - endTime ) > 1000) {
-                result[result.length - 1].ts  = endTime + 1000;
+            if ( result[result.length - 1].ts < endTime ) {
+                result[result.length - 1] = interpolateData(result[result.length - 2], result[result.length - 1], endTime);
             }   
         }
 
@@ -1641,18 +1645,18 @@ function getHistoryIflx2(adapter, msg) {
                 }
             }
 
-            if ((result.length > 0) && ((options.aggregate === 'minmax' || options.aggregate === 'onchange' || options.aggregate === 'none'))) {
+            if ((result.length > 2) && ((options.aggregate === 'minmax' || options.aggregate === 'onchange' || options.aggregate === 'none'))) {
                 if (options.start) {
                     const startTime = new Date(options.start).getTime();
-                    if (startTime - result[0].ts > 1000) {
-                        result[0].ts = startTime - 1000
+                    if (startTime > result[0].ts) {
+                        result[0] = interpolateData(result[0], result[1], startTime);
                     }
                 }
                 const endTime = new Date(options.end).getTime();
-                if ( (result[result.length - 1].ts - endTime ) > 1000) {
-                    result[result.length - 1].ts  = endTime + 1000;
+                if ( result[result.length - 1].ts < endTime ) {
+                    result[result.length - 1] = interpolateData(result[result.length - 2], result[result.length - 1], endTime);
                 }   
-            }   
+            }
 
             if ((result.length > 0) && (options.aggregate === 'minmax')) {
                 Aggregate.initAggregate(options);

--- a/main.js
+++ b/main.js
@@ -1352,7 +1352,7 @@ function getHistory(adapter, msg) {
         options.limit += 2;
     }
 
-    query += " WHERE ";
+    query += ` WHERE `;
     if (options.start) {
         query += " time > '" + new Date(options.start).toISOString() + "' AND ";
     }
@@ -1430,7 +1430,7 @@ function getHistory(adapter, msg) {
             }   
         }
 
-        if ((result.length > 0) && (options.aggregate === 'minmax')) {
+        if (result.length > 0 && options.aggregate === 'minmax') {
             Aggregate.initAggregate(options);
             Aggregate.aggregation(options, result);
             Aggregate.finishAggregation(options);

--- a/main.js
+++ b/main.js
@@ -1364,21 +1364,15 @@ function getHistory(adapter, msg) {
         query += ' LIMIT ' + options.count;
     }
 
-    let 
-        isPrefixAdded = false,
-        isSuffixAdded = false;
-
     // select one datapoint more then wanted
     if (options.aggregate === 'minmax' || options.aggregate === 'onchange' || options.aggregate === 'none') {
         let addQuery = '';
         if (options.start) {
             addQuery = 'SELECT value from "' + options.id + '"' + " WHERE time <= '" + new Date(options.start).toISOString() + "' ORDER BY time DESC LIMIT 1;";
             query = addQuery + query;
-            isPrefixAdded = true;
         }
         addQuery = ';SELECT value from "' + options.id + '"' + " WHERE time >= '" + new Date(options.end).toISOString() + "' LIMIT 1";
         query = query + addQuery;
-        isSuffixAdded = true;
     }
 
     adapter.log.debug(query);
@@ -1404,18 +1398,6 @@ function getHistory(adapter, msg) {
                         delete rows[qr][rr].value;
                     }
                     rows[qr][rr].ts  = new Date(rows[qr][rr].time).getTime();
-                    if (isPrefixAdded && (qr === 0) && (rr === 0)) {
-                        const startTime = new Date(options.start).getTime();
-                        if ( (startTime - rows[qr][rr].ts) > 1000) {
-                            rows[qr][rr].ts  = startTime - 1000;
-                        }
-                    }
-                    if (isSuffixAdded && (qr === rowsLast) && (rr === (rows[qr].length - 1) )) {
-                        const endTime = new Date(options.end).getTime();
-                        if ( (rows[qr][rr].ts - endTime ) > 1000) {
-                            rows[qr][rr].ts  = endTime + 1000;
-                        }
-                    }
                     delete rows[qr][rr].time;
                     if (rows[qr][rr].val !== null) {
                         const f = parseFloat(rows[qr][rr].val);
@@ -1430,6 +1412,19 @@ function getHistory(adapter, msg) {
                     result.push(rows[qr][rr]);
                 }
             }
+        }
+
+        if ((result.length > 0) && ((options.aggregate === 'minmax' || options.aggregate === 'onchange' || options.aggregate === 'none'))) {
+            if (options.start) {
+                const startTime = new Date(options.start).getTime();
+                if (startTime - result[0].time > 1000) {
+                    result[0].time = startTime - 1000
+                }
+            }
+            const endTime = new Date(options.end).getTime();
+            if ( (result[result.length - 1].time - endTime ) > 1000) {
+                result[result.length - 1].time  = endTime + 1000;
+            }   
         }
 
         if ((result.length > 0) && (options.aggregate === 'minmax')) {
@@ -1581,10 +1576,6 @@ function getHistoryIflx2(adapter, msg) {
 
         fluxQueries.push(fluxQuery);
 
-        let 
-            isPrefixAdded = false,
-            isSuffixAdded = false;
-
         // select one datapoint more then wanted
         if (options.aggregate === 'minmax' || options.aggregate === 'onchange' || options.aggregate === 'none') {
             let addFluxQuery = '';
@@ -1601,7 +1592,6 @@ function getHistoryIflx2(adapter, msg) {
                 const mainQuery = fluxQueries.pop();
                 fluxQueries.push(addFluxQuery);
                 fluxQueries.push(mainQuery);
-                isPrefixAdded = true;
             }
             // get one entry "after" the defined timeframe for displaying purposes
             addFluxQuery = 'from(bucket: "' + adapter.config.dbname + '") \
@@ -1613,7 +1603,6 @@ function getHistoryIflx2(adapter, msg) {
                 |> limit(n: 1)';
             //fluxQuery = fluxQuery + addFluxQuery;
             fluxQueries.push(addFluxQuery);
-            isSuffixAdded = true;
         }
 
         adapter.log.debug('History-queries to execute: ' + fluxQueries);
@@ -1638,19 +1627,7 @@ function getHistoryIflx2(adapter, msg) {
                             rows[qr][rr].val = rows[qr][rr].value;
                             delete rows[qr][rr].value;
                         }
-                        rows[qr][rr].ts  = new Date(rows[qr][rr].time).getTime();
-                        if (isPrefixAdded && (qr === 0) && (rr === 0)) {
-                            const startTime = new Date(options.start).getTime();
-                            if ( (startTime - rows[qr][rr].ts) > 1000) {
-                                rows[qr][rr].ts  = startTime - 1000;
-                            }
-                        }
-                        if (isSuffixAdded && (qr === rowsLast) && (rr === (rows[qr].length - 1))) {
-                            const endTime = new Date(options.end).getTime();
-                            if ( (rows[qr][rr].ts - endTime ) > 1000) {
-                                rows[qr][rr].ts  = endTime + 1000;
-                            }
-                        }                        
+                        rows[qr][rr].ts  = new Date(rows[qr][rr].time).getTime();                     
                         delete rows[qr][rr].time;
                         if (rows[qr][rr].val !== null) {
                             const f = parseFloat(rows[qr][rr].val);
@@ -1666,6 +1643,19 @@ function getHistoryIflx2(adapter, msg) {
                     }
                 }
             }
+
+            if ((result.length > 0) && ((options.aggregate === 'minmax' || options.aggregate === 'onchange' || options.aggregate === 'none'))) {
+                if (options.start) {
+                    const startTime = new Date(options.start).getTime();
+                    if (startTime - result[0].time > 1000) {
+                        result[0].time = startTime - 1000
+                    }
+                }
+                const endTime = new Date(options.end).getTime();
+                if ( (result[result.length - 1].time - endTime ) > 1000) {
+                    result[result.length - 1].time  = endTime + 1000;
+                }   
+            }   
 
             if ((result.length > 0) && (options.aggregate === 'minmax')) {
                 Aggregate.initAggregate(options);

--- a/main.js
+++ b/main.js
@@ -1418,15 +1418,15 @@ function getHistory(adapter, msg) {
         }
 
         if ((result.length > 2) && ((options.aggregate === 'minmax' || options.aggregate === 'onchange' || options.aggregate === 'none'))) {
-            if (options.start ) {
+            if (options.start) {
                 const startTime = new Date(options.start).getTime();
                 if (startTime > result[0].ts) {
-                    result[0] = interpolateData(result[0], result[1], startTime);
+                    result[0]= {...result[0], ...interpolateData(result[0], result[1], startTime)};
                 }
             }
             const endTime = new Date(options.end).getTime();
-            if ( result[result.length - 1].ts < endTime ) {
-                result[result.length - 1] = interpolateData(result[result.length - 2], result[result.length - 1], endTime);
+            if ( result[result.length - 1].ts > endTime ) {
+                result[result.length - 1] = {...result[result.length - 1], ...interpolateData(result[result.length - 2], result[result.length - 1], endTime)};
             }   
         }
 
@@ -1650,12 +1650,12 @@ function getHistoryIflx2(adapter, msg) {
                 if (options.start) {
                     const startTime = new Date(options.start).getTime();
                     if (startTime > result[0].ts) {
-                        result[0] = interpolateData(result[0], result[1], startTime);
+                        result[0]= {...result[0], ...interpolateData(result[0], result[1], startTime)};
                     }
                 }
                 const endTime = new Date(options.end).getTime();
-                if ( result[result.length - 1].ts < endTime ) {
-                    result[result.length - 1] = interpolateData(result[result.length - 2], result[result.length - 1], endTime);
+                if ( result[result.length - 1].ts > endTime ) {
+                    result[result.length - 1] = {...result[result.length - 1], ...interpolateData(result[result.length - 2], result[result.length - 1], endTime)};
                 }   
             }
 


### PR DESCRIPTION
Currently in this adapter in functions getHistory/getHistoryIflx2 the history data is requested from database  not only inside of the time interval, received by getHistory request, but, for "smooth" drawing, one value before and one after in the appropriate timeseries...
But, in some cases, the timestamp of this "additional" data-points can be significantly differ from begin and end values(borders) of requested time interval... Up to several days ...
To avoid it the time stamp of this data-points will be manually set as much close to the "borders" as possible. In proposed PR it is equal to 1 second.