### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,6 +393,7 @@ sendTo('influxdb.0', 'getEnabledDPs', {}, function (result) {
 * (bluefox) Implemented option to ignore zero- or/and below zero- values
 
 ### 2.2.0 (2021-08-25)
+* IMPORTANT: You need to re-enter the password after installing this version!
 * (Excodibur) Added option to store metadata (q, ack, from) as tags instead of fields for Influx 2.x - see README!
 * (Excodibur) Failure to update/set retention policy will now cause warning instead of error/restart, to support more restrictive DB setups
 * (Excodibur/Apollon77) Bug fixes and adjustments


### PR DESCRIPTION
The password for the influxDB needs to be entered again, otherwise the connection to the database fails (adapter remains yellow) and the log states "no connection to the database possible". The adapter config indicates that a password has already been entered, therefore it's hard to figure out what's wrong.