### PR TITLE
Add an option to store only values (no metadata)

### DIFF
--- a/admin/jsonConfig.json
+++ b/admin/jsonConfig.json
@@ -341,18 +341,21 @@
       "type": "panel",
       "label": "Expert Settings",
       "items": {
-        "usetags": {
-          "type": "checkbox",
+        "metaDataStorage": {
+          "type": "select",
           "sm": 12,
           "md": 6,
-          "min": 0,
+          "options": [
+            {"label": "Fields", "value": "fields"},
+            {"label": "Tags", "value": "tags"}
+          ],
           "label": "Use tags to store metadata information, instead of fields",
           "help": "usetags help",
           "hidden": "data.dbversion === '1.x'",
           "disabled": "data.dbversion === '1.x'",
           "confirm": {
             "text": "This feature can only be used on databases that are empty, or already were setup with this feature enabled. Otherwise it will cause errors (see logs).",
-            "condition": "data.usetags && data.usetags != originalData.usetags",
+            "condition": "data.metaDataStorage && data.metaDataStorage != originalData.metaDataStorage",
             "title": "Please confirm!",
             "type": "warning"
           }

--- a/admin/jsonConfig.json
+++ b/admin/jsonConfig.json
@@ -347,7 +347,8 @@
           "md": 6,
           "options": [
             {"label": "Fields", "value": "fields"},
-            {"label": "Tags", "value": "tags"}
+            {"label": "Tags", "value": "tags"},
+            {"label": "Plain (store only values)", "value": "plain"}
           ],
           "label": "Use tags to store metadata information, instead of fields",
           "help": "usetags help",

--- a/io-package.json
+++ b/io-package.json
@@ -282,7 +282,7 @@
     "requestTimeout": 30000,
     "validateSSL": true,
     "dbversion": "1.x",
-    "usetags": false,
+    "metaDataStorage": "fields",
     "pingserver": true,
     "blockTime": 0,
     "debounceTime": 0,

--- a/lib/DatabaseInfluxDB2x.js
+++ b/lib/DatabaseInfluxDB2x.js
@@ -22,7 +22,7 @@ class FakeConnectionPool {
 
 //Influx 2.x auth requires token, not user/pw
 class DatabaseInfluxDB2x extends Database {
-    constructor(log, host, port, protocol, path, token, organization, database, requestTimeout, validateSSL, metaDataStorage, timePrecision) {
+    constructor(log, host, port, protocol, path, token, organization, database, requestTimeout, validateSSL, metaDataStorage, defaultMeasurement, timePrecision) {
         super();
 
         this.log = log;
@@ -37,6 +37,7 @@ class DatabaseInfluxDB2x extends Database {
         this.timePrecision = timePrecision; // ms
         this.requestTimeout = requestTimeout; // 30000
         this.metaDataStorage = metaDataStorage;
+        this.defaultMeasurement = defaultMeasurement;
         this.validateSSL = validateSSL;
 
         this.request = new FakeConnectionPool();
@@ -217,32 +218,30 @@ class DatabaseInfluxDB2x extends Database {
     }
 
     stateValueToPoint(pointName, stateValue) {
-        let point = null;
+        const [measurement, fieldName] = this.getMeasurementAndFieldName(pointName);
+        const point = new InfluxClient.Point(measurement)
+            .timestamp(stateValue.time);
 
         if (this.metaDataStorage === 'tags') {
-            point = new InfluxClient.Point(pointName)
-                .timestamp(stateValue.time)
-                .tag('q', String(stateValue.q))
+            point.tag('q', String(stateValue.q))
                 .tag('ack', String(stateValue.ack))
                 .tag('from', stateValue.from);
-        } else {
-            point = new InfluxClient.Point(pointName)
-                .timestamp(stateValue.time)
-                .floatField('q', stateValue.q)
+        } else if (this.metaDataStorage === 'fields') {
+            point.floatField('q', stateValue.q)
                 .booleanField('ack', stateValue.ack)
                 .stringField('from', stateValue.from);
         }
 
         switch (typeof stateValue.value) {
             case 'boolean':
-                point.booleanField('value', stateValue.value);
+                point.booleanField(fieldName, stateValue.value);
                 break;
             case 'number':
-                point.floatField('value', parseFloat(stateValue.value));
+                point.floatField(fieldName, parseFloat(stateValue.value));
                 break;
             case 'string':
             default:
-                point.stringField('value', stateValue.value);
+                point.stringField(fieldName, stateValue.value);
                 break;
         }
         return point;
@@ -305,6 +304,9 @@ class DatabaseInfluxDB2x extends Database {
                         }
                     });
                 }
+                if (metaDataStorage == 'none' && result[1].length) {
+                    metaDataStorage = 'plain';
+                }
                 callback(null, metaDataStorage);
             }
 
@@ -343,6 +345,21 @@ class DatabaseInfluxDB2x extends Database {
         // can't do much with interval, so ignoring it for compatibility reasons
         return this.healthApi.getHealth()
             .then(result => result.status === 'pass' ? [{ online: true }] : [{ online: false }]);
+    }
+
+    getMeasurementAndFieldName(pointName) {
+        if (this.metaDataStorage == 'plain') {
+            if (pointName.includes('>')) {
+                // Measurement explicitly specified.
+                return pointName.split(/\s*>\s*/, 2);
+            } else {
+                // Default measurement.
+                return [this.defaultMeasurement, pointName];
+            }
+        } else {
+            // Same behavior as before if we really store metadata.
+            return [pointName, 'value'];
+        }
     }
 }
 

--- a/lib/DatabaseInfluxDB2x.js
+++ b/lib/DatabaseInfluxDB2x.js
@@ -22,7 +22,7 @@ class FakeConnectionPool {
 
 //Influx 2.x auth requires token, not user/pw
 class DatabaseInfluxDB2x extends Database {
-    constructor(log, host, port, protocol, path, token, organization, database, requestTimeout, validateSSL, useTags, timePrecision) {
+    constructor(log, host, port, protocol, path, token, organization, database, requestTimeout, validateSSL, metaDataStorage, timePrecision) {
         super();
 
         this.log = log;
@@ -36,7 +36,7 @@ class DatabaseInfluxDB2x extends Database {
         this.database = database;
         this.timePrecision = timePrecision; // ms
         this.requestTimeout = requestTimeout; // 30000
-        this.useTags = useTags || false;
+        this.metaDataStorage = metaDataStorage;
         this.validateSSL = validateSSL;
 
         this.request = new FakeConnectionPool();
@@ -219,7 +219,7 @@ class DatabaseInfluxDB2x extends Database {
     stateValueToPoint(pointName, stateValue) {
         let point = null;
 
-        if (this.useTags) {
+        if (this.metaDataStorage === 'tags') {
             point = new InfluxClient.Point(pointName)
                 .timestamp(stateValue.time)
                 .tag('q', String(stateValue.q))
@@ -289,7 +289,7 @@ class DatabaseInfluxDB2x extends Database {
         ];
 
         this.queries(queries, (error, result) => {
-            let storageType = "none";
+            let metaDataStorage = "none";
             if (error) {
                 callback(error, null);
             } else {
@@ -300,12 +300,12 @@ class DatabaseInfluxDB2x extends Database {
                             case 'q':
                             case 'ack':
                             case 'from':
-                                storageType = i == 0 ? 'tags' : 'fields';
+                                metaDataStorage = i == 0 ? 'tags' : 'fields';
                                 return;
                         }
                     });
                 }
-                callback(null, storageType);
+                callback(null, metaDataStorage);
             }
 
         });

--- a/test/testAdapterTags.js
+++ b/test/testAdapterTags.js
@@ -107,7 +107,7 @@ describe(`Test ${adapterShortName} adapter`, function () {
             }
             config.native.enableDebugLogs = true;
             config.native.dbname = 'tagsiobroker';
-            config.native.usetags = true;
+            config.native.metaDataStorage = 'tags';
 
             await setup.setAdapterConfig(config.common, config.native);
 


### PR DESCRIPTION
I have an InfluxDB which I've filled directly from Python scripts so far and which I visualize in Grafana. Now I'm slowly integrating these devices into ioBroker and would like to keep the values in the same database schema. For example, I have a bucket called "smarthome" with a measurement "heating" and in there I have multiple fields like "flow_temp", "return_temp" etc. I don't care to store the ioBroker metadata ("q", "ack", "from"), I just want to have the values in the same format as before.

Therefore I have refactored the codebase to use a select instead of a checkbox for the metadata storage type and then added a new type for just the values. The field name isn't "value" anymore but the point name (or usually the alias) and the default measurement is the database name instead of the point name. I plan to add a setting for the measurement name. It's possible to override the measurement by setting the alias to "my_measurement > my_field_name". As far as I understood, the ">" character is forbidden in object IDs.

Schema for classical metadata storage types (fields/tags):
| Object ID | Alias | Measurement | Field |
| - | - | - | - |
| worx.0.123.mower.batteryState | | worx.0.123.mower.batteryState | value |
| worx.0.123.mower.batteryState | mower_battery | mower_battery | value |

Schema for new metadata storage type (with default measurement = "smarthome"):
| Object ID | Alias | Measurement | Field |
| - | - | - | - |
| worx.0.123.mower.batteryState | | smarthome | worx.0.123.mower.batteryState |
| worx.0.123.mower.batteryState | mower_battery | smarthome | mower_battery |
| worx.0.123.mower.batteryState | mower > battery | mower | battery |

I believe this is more generic, not ioBroker-specific and could work very well with custom tags (#278). I'm also not sure if it's possible to have different datatypes for the same field "value", even if they're in different measurements?!? For differently named fields that should definitely be possible.

---

I'm not finished yet, the open points are listed in the commit messages. I also want to send another PR for an option to store only acknowledged states. Anyway, I'd appreciate if someone (@Apollon77?) could have a brief early look and tell me if there's a chance to get this merged or if there's something important missing.