### PR TITLE
Update admin dependency version to >=7.7.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,6 +460,7 @@ sendTo('influxdb.0', 'getEnabledDPs', {}, function (result) {
 ### **WORK IN PROGRESS**
 * (bluefox) Completely refactored the code to TypeScript and ES6
 * (bluefox) Added possibility to start docker containers directly from the adapter
+* (mcm1957) Adapter requires admin >= 7.7.2 now
 
 ### 4.0.3 (2024-05-16)
 * (bluefox) Some packages were updated

--- a/io-package.json
+++ b/io-package.json
@@ -141,7 +141,7 @@
     ],
     "globalDependencies": [
       {
-        "admin": ">=5.1.28"
+        "admin": ">=7.7.2"
       }
     ],
     "supportStopInstance": 10000,


### PR DESCRIPTION
Adapter requires at least admin 7.7.2 as checkDocker component used at adminUI was added with 7.7.2 according to admin README.md